### PR TITLE
chore: run version on correct branch

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - master
 
 jobs:
   covector:


### PR DESCRIPTION
This repo hasn't had the `master` branch converted over yet.